### PR TITLE
fixes runtime error: index out of range when not passing any task argument

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -11,12 +11,12 @@ import (
 func main() {
 	ctx := context.Background()
 
-	task := os.Args[1]
-
 	if len(os.Args) != 2 {
 		fmt.Println("Please pass a task as an argument")
 		os.Exit(1)
 	}
+
+	task := os.Args[1]
 
 	var err error
 


### PR DESCRIPTION
Fixes the following:

```
$ go run ./ci/main.go
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.main()
        /Users/shad/forks/greetings-api/ci/main.go:14 +0x24c
exit status 2
```