### PR TITLE
Limit main content width to 50% of screen

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -7,7 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body class="bg-purple-900 text-white font-sans flex flex-col items-center justify-center min-h-screen">
-    <div class="container mx-auto px-4 py-8">
+    <div class="container mx-auto px-4 py-8 max-w-screen-md">
         <h1 class="text-3xl font-bold mb-4">Greetings Daggernauts</h1>
         <div id="greetingDisplay" class="greeting bg-purple-700 rounded shadow p-4 min-h-20 flex items-center justify-center">
             Click the button to see a greeting!


### PR DESCRIPTION
The main content of the site is too wide. Make it only use the middle half of the screen

Completed by Agent
Fixes https://github.com/kpenfound/greetings-api/issues/104
