### PR TITLE
use github diff URL instead of calculating diffs

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -16,7 +16,7 @@
     {
       "name": "github-issue",
       "source": "github.com/kpenfound/dag/github-issue",
-      "pin": "cecae6c3ccfaa9efce87af20a1b4e09410013742"
+      "pin": "1e4b1ee3a519b7e5d20bb977260bd48b42c349ca"
     },
     {
       "name": "github-release",


### PR DESCRIPTION
Calculating the diff is hard if we dont know the branch's base, but this URL gives us the diff so we can just use it